### PR TITLE
Load level by URL instead of ID that references massassi.net

### DIFF
--- a/episode.py
+++ b/episode.py
@@ -1,6 +1,5 @@
 import io
 import re
-import struct
 import sys
 
 ITEM_RE = re.compile(

--- a/fixups/readme.txt
+++ b/fixups/readme.txt
@@ -1,1 +1,0 @@
-Fixups that replace files available from Massassi can be put here

--- a/server.py
+++ b/server.py
@@ -1,13 +1,15 @@
-from flask import Flask, Response, render_template, request, send_file, send_from_directory
+from flask import Flask, Response, render_template, request, send_from_directory
 from flask_compress import Compress
 
 import base64
+import hashlib
 import json
 import os
 import re
 import shutil
 import tempfile
 import urllib.request
+import urllib.parse
 import zipfile
 
 import episode
@@ -24,23 +26,10 @@ CENSOR_ALWAYS = False
 ALWAYS_REGEN = False
 
 # increment VERSION to invalidate caches
-VERSION = 6
+VERSION = 7
 
-# comment embedded in the level info page now provides a direct download link
-# so we don't have to call "download_level.php" to get the actual download
-# (which increases level download counts).
-DOWNLOAD_LINK_RE = re.compile(
-    br'<!-- DIRECT DOWNLOAD: \d+ (/.+.zip) -->')
-
-# The base url for downloads.  For main massassi server this is usually
-# "https://www.massassi.net".  Setting it via an environment variable so I can
-# easily query other servers (for example local dev containers or massassi dev
-# server which is served off a different url).
-DOWNLOAD_BASE_URL = os.getenv('DOWNLOAD_BASE_URL')
-
-def _find_download_link(trampoline_html):
-    match = DOWNLOAD_LINK_RE.search(trampoline_html)
-    return match.group(1).decode() if match else ''
+# allowed prefixes for level URLs
+ALLOWED_URL_PREFIXES = ['https://www.massassi.net/media/levels/files/']
 
 
 def _atomically_dump(f, target_path):
@@ -53,12 +42,17 @@ def _atomically_dump(f, target_path):
             raise
 
 
-def _get_cache_filename(level_id, episode_id, filename):
+def _get_level_id(zip_url):
+    return hashlib.sha1(zip_url.encode("utf-8")).hexdigest()
+
+
+def _get_cache_filename(zip_url, episode_id, filename):
+    level_id = _get_level_id(zip_url)
     return os.path.join('cache', '{0}-{1}-{2}'.format(level_id, episode_id, filename))
 
 
-def _write_cache_atomically(level_id, episode_id, filename, mode, data):
-    target_path = _get_cache_filename(level_id, episode_id, filename)
+def _write_cache_atomically(zip_url, episode_id, filename, mode, data):
+    target_path = _get_cache_filename(zip_url, episode_id, filename)
     with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
         try:
             with open(tmp_file.name, mode) as f:
@@ -77,22 +71,15 @@ def _encode_color(tuple):
     return '#%02x%02x%02x' % (tuple[0], tuple[1], tuple[2])
 
 
-def _extract_level(level_id):
-    level_id = int(level_id)  # sanitize
+def _extract_level(zip_url):
+    level_id = _get_level_id(zip_url)
 
     gob_path = os.path.join('downloads', '{}.gob'.format(level_id))
     if not os.path.isfile(gob_path):
-        fixup_path = os.path.join('fixups', '{}.zip'.format(level_id))
-        if os.path.isfile(fixup_path):
-            zip_path = fixup_path
-        else:
-            zip_path = os.path.join('downloads', '{}.zip'.format(level_id))
-            if not os.path.isfile(zip_path):
-                url = DOWNLOAD_BASE_URL + '/levels/files/{}.shtml'.format(level_id)
-                with urllib.request.urlopen(url) as page:
-                    zip_url = _find_download_link(page.read())
-                with urllib.request.urlopen(DOWNLOAD_BASE_URL + zip_url) as level_zip:
-                    _atomically_dump(level_zip, zip_path)
+        zip_path = os.path.join('downloads', '{}.zip'.format(level_id))
+        if not os.path.isfile(zip_path):
+            with urllib.request.urlopen(zip_url) as level_zip:
+                _atomically_dump(level_zip, zip_path)
 
         with zipfile.ZipFile(zip_path) as level_zip:
             # locate the first gob file and write its contents atomically to gob_path
@@ -121,7 +108,7 @@ def _extract_level(level_id):
                 surfaces, model_surfaces, materials = loader.load_level_from_gob(
                     levelname, gob_path)
 
-                # devide vertex UVs by texture sizes
+                # divide vertex UVs by texture sizes
                 for src in [surfaces, model_surfaces]:
                     for surf in src:
                         mat = materials[surf['material']]
@@ -148,7 +135,7 @@ def _extract_level(level_id):
 
                     matjs_filename = 'mat{0}.json'.format(
                         '' if censor else '-full')
-                    _write_cache_atomically(level_id, episode_id, matjs_filename,
+                    _write_cache_atomically(zip_url, episode_id, matjs_filename,
                                             'wt', json.dumps(material_data))
 
                 # assemble map data
@@ -156,7 +143,7 @@ def _extract_level(level_id):
                     mat['color']) if mat else '#000000' for mat in materials]
                 map_data = {'surfaces': surfaces, 'model_surfaces': model_surfaces,
                             'material_colors': material_colors}
-                _write_cache_atomically(level_id, episode_id, 'map.json',
+                _write_cache_atomically(zip_url, episode_id, 'map.json',
                                         'wt', json.dumps(map_data))
 
                 if levelname.endswith(b'.jkl'):
@@ -168,92 +155,80 @@ def _extract_level(level_id):
         pass  # well ... not much we can do
     finally:
         # always write the file to avoid retrying the extraction
-        _write_cache_atomically(level_id, 'all', 'mapinfo.json',
+        _write_cache_atomically(zip_url, 'all', 'mapinfo.json',
                                 'wt', json.dumps(level_info))
 
     return level_info
 
 
-def _serve_map_data(level_id, episode_id):
-    mapjs_path = _get_cache_filename(level_id, episode_id, 'map.json')
+def _is_zip_url_allowed(url):
+    for allowed_prefix in ALLOWED_URL_PREFIXES:
+        if url.startswith(allowed_prefix):
+            return True
+    return False
+
+
+def _get_zip_url():
+    url = urllib.parse.urlparse(request.args.get('url')).geturl()
+    if not url or not _is_zip_url_allowed(url):
+        raise Exception('url missing or not allowed!')
+    return url
+
+
+@app.route('/level/map.json')
+def root_level_map_data():
+    zip_url = _get_zip_url()
+    episode_id = int(request.args.get('episode', 0))
+    level_id = _get_level_id(zip_url)
     return send_from_directory('cache', '{0}-{1}-{2}'.format(level_id, episode_id, 'map.json'))
 
 
-def _serve_material_data(level_id, episode_id):
+@app.route('/level/mat.json')
+def root_level_material_data():
+    zip_url = _get_zip_url()
+    episode_id = int(request.args.get('episode', 0))
+    level_id = _get_level_id(zip_url)
     censor = CENSOR_ALWAYS or request.args.get('ownsgame') != '1'
     matjs_filename = 'mat{0}.json'.format('' if censor else '-full')
     return send_from_directory('cache', '{0}-{1}-{2}'.format(level_id, episode_id, matjs_filename))
 
 
-def _is_fixup_available(level_id):
-    level_id = int(level_id)  # sanitize
-
-    fixup_path = os.path.join('fixups', '{}.zip'.format(level_id))
-    return os.path.isfile(fixup_path)
-
-
-def _get_mapinfo(level_id):
-    level_id = int(level_id)  # sanitize
-
+def _get_mapinfo(zip_url):
     if not ALWAYS_REGEN:
-        mapinfo_path = _get_cache_filename(level_id, 'all', 'mapinfo.json')
+        mapinfo_path = _get_cache_filename(zip_url, 'all', 'mapinfo.json')
         if os.path.exists(mapinfo_path):
             with open(mapinfo_path, 'rt') as f:
                 level_info = json.loads(f.read())
                 if 'version' in level_info and level_info['version'] == VERSION:
-                    try_regen = not level_info['maps'] and _is_fixup_available(
-                        level_id)
-                    if not try_regen:
-                        return level_info  # cached info exists and has correct version. use it!
+                    return level_info  # cached info exists and has correct version. use it!
 
-    return _extract_level(level_id)
+    return _extract_level(zip_url)
 
 
-def _serve_map(level_id, url_has_episode):
-    level_info = _get_mapinfo(level_id)
+@app.route('/level/')
+def root_level_viewer():
+    zip_url = _get_zip_url()
+    episode_id = int(request.args.get('episode', 0))
+    level_info = _get_mapinfo(zip_url)
 
     censor = CENSOR_ALWAYS or request.args.get('ownsgame') != '1'
 
-    mapjs_url = 'map.json?version={0}'.format(VERSION)
+    mapjs_url = 'map.json?version={0}&url={1}&episode={2}'.format(
+        VERSION, zip_url, episode_id)
     if not censor:
         mapjs_url += '&ownsgame=1'
 
-    matjs_url = 'mat.json?version={0}'.format(VERSION)
+    matjs_url = 'mat.json?version={0}&url={1}&episode={2}'.format(
+        VERSION, zip_url, episode_id)
     if not censor:
         matjs_url += '&ownsgame=1'
 
-    ownsgame = '' if censor else '?ownsgame=1'
-    link_adjust = '../' if url_has_episode else ''
+    maps = []
+    for i, map in enumerate(level_info['maps']):
+        episode_url = '?url={0}&episode={1}'.format(zip_url, i)
+        if not censor:
+            episode_url += '&ownsgame=1'
+        maps.append([map, episode_url])
 
-    return render_template('viewer.html', title=level_info['title'], maps=json.dumps(level_info['maps']),
-                           map_js=mapjs_url, mat_js=matjs_url, ownsgame=ownsgame, link_adjust=link_adjust)
-
-
-@app.route('/level/<int:level_id>/<int:episode_id>/map.json')
-def level_map_data(level_id, episode_id):
-    return _serve_map_data(level_id, episode_id)
-
-
-@app.route('/level/<int:level_id>/<int:episode_id>/mat.json')
-def level_material_data(level_id, episode_id):
-    return _serve_material_data(level_id, episode_id)
-
-
-@app.route('/level/<int:level_id>/<int:episode_id>/')
-def level_viewer(level_id, episode_id):
-    return _serve_map(level_id, True)
-
-
-@app.route('/level/<int:level_id>/map.json')
-def root_level_map_data(level_id):
-    return _serve_map_data(level_id, 0)
-
-
-@app.route('/level/<int:level_id>/mat.json')
-def root_level_material_data(level_id):
-    return _serve_material_data(level_id, 0)
-
-
-@app.route('/level/<int:level_id>/')
-def root_level_viewer(level_id):
-    return _serve_map(level_id, False)
+    return render_template('viewer.html', title=level_info['title'], maps=json.dumps(maps),
+                           map_js=mapjs_url, mat_js=matjs_url)

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -96,17 +96,15 @@
         if (maps.length > 1) {
             var mapinfoList = document.getElementById('mapinfolist');
             for (var i = 0; i < maps.length; ++i) {
-                var name = maps[i];
+                var name_and_link = maps[i];
+                var name = name_and_link[0];
 
                 var linkText = document.createTextNode(name);
 
                 var a = document.createElement('a');
                 a.appendChild(linkText);
                 a.title = "Switch to map " + name;
-                if (i == 0)
-                    a.href = "{{link_adjust}}{{ ownsgame|safe }}";
-                else
-                    a.href = "{{link_adjust}}" + i + "/{{ ownsgame|safe }}";
+                a.href = name_and_link[1];
 
                 var li = document.createElement("li");
                 li.appendChild(a);


### PR DESCRIPTION
As proposed by @saberworks, unties us from massassi.net and allows reuse on other sites.

Example for viewing a level hosted on massassi.net:
http://127.0.0.1:5000/level/?url=https://www.massassi.net/media/levels/files/jksp/FGR6.zip

ALLOWED_URL_PREFIXES in server.py controls allowed sources.