### PR TITLE
config variables pulled out into separate file

### DIFF
--- a/config.py-default
+++ b/config.py-default
@@ -1,0 +1,21 @@
+#
+# The default configuration file.  Rename or copy it to `config.py`
+# and change the values to suit your installation.
+#
+
+# enable CENSOR_ALWAYS to avoid extraction of full-resolution assets on server
+CENSOR_ALWAYS = False
+
+# enable ALWAYS_REGEN to regenerate level data on every request.
+# FOR DEVELOPMENT ONLY!
+ALWAYS_REGEN = False
+
+# increment VERSION to invalidate caches
+VERSION = 7
+
+# allowed prefixes for level URLs
+ALLOWED_URL_PREFIXES = [
+    'https://www.massassi.net/media/levels/files/',
+    'https://www.jkdf2.net/JKBot/JKArchive/JKDF2/JKDF2/',
+    'https://jkdf2.net/JKBot/JKArchive/JKDF2/JKDF2/',
+]

--- a/server.py
+++ b/server.py
@@ -19,17 +19,7 @@ import loader
 app = Flask(__name__)
 Compress(app)
 
-# enable CENSOR_ALWAYS to avoid extraction of full-resolution assets on server
-CENSOR_ALWAYS = False
-
-# enable ALWAYS_REGEN to regenerate level data on every request. FOR DEVELOPMENT ONLY!
-ALWAYS_REGEN = False
-
-# increment VERSION to invalidate caches
-VERSION = 7
-
-# allowed prefixes for level URLs
-ALLOWED_URL_PREFIXES = ['https://www.massassi.net/media/levels/files/']
+from config import *
 
 
 def _atomically_dump(f, target_path):


### PR DESCRIPTION
This allows me to store `config.py` separately (not in source control) and not have to modify `server.py` each time a new change needs to be deployed.