### PR TITLE
Support jumping to spawn points in the map.

### DIFF
--- a/config.py-default
+++ b/config.py-default
@@ -11,7 +11,7 @@ CENSOR_ALWAYS = False
 ALWAYS_REGEN = False
 
 # increment VERSION to invalidate caches
-VERSION = 7
+VERSION = 8
 
 # allowed prefixes for level URLs
 ALLOWED_URL_PREFIXES = [

--- a/jkl.py
+++ b/jkl.py
@@ -107,7 +107,7 @@ class JklFile:
                 key = int(match.group(1))
                 mat = int(match.group(2))
                 surfflags = int(match.group(3)[2:], 16)
-                faceflags = int(match.group(4)[2:], 16)
+                #faceflags = int(match.group(4)[2:], 16)
                 geo = int(match.group(5))
                 #light = int(match.group(6))
                 #tex = int(match.group(7))
@@ -215,10 +215,11 @@ class JklFile:
 
     def _read_things(self, lines, templates):
         models = []
+        spawn_points = []
         for line in lines:
             match = THING_RE.match(line)
             if match:
-                key = int(match.group(1))
+                #key = int(match.group(1))
                 template = match.group(2).lower()
                 name = match.group(3)
                 x = float(match.group(4))
@@ -238,7 +239,10 @@ class JklFile:
                     mdl = {'pos': (x, y, z), 'rot': (
                         pitch, yaw, roll), 'sector': sector, 'model': config[b'model3d']}
                     models.append(mdl)
+                if name == b'walkplayer':
+                    spawn_points.append({'pos': (x, y, z), 'rot': (pitch, yaw, roll)})
         self.models = models
+        self.spawn_points = spawn_points
 
 
 def _strip(line):
@@ -256,7 +260,7 @@ def _ends_section(line):
     return line == b'end' or _defines_section(line)
 
 
-def _parse_section(lines, f, section):
+def _parse_section(lines, f):
     for line in f:
         line = _strip(line)
         if not line:
@@ -274,7 +278,7 @@ def read_from_file(f):
             while _defines_section(line):
                 section = line[8:].strip().lower()
                 section_lines = []
-                line = _parse_section(section_lines, f, section)
+                line = _parse_section(section_lines, f)
                 sections[section] = section_lines
         return JklFile(sections)
 

--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
-from flask import Flask, Response, render_template, request, send_from_directory
+from config import *
+from flask import Flask, Response, render_template, request, send_file, send_from_directory
 from flask_compress import Compress
 
 import base64
@@ -18,8 +19,6 @@ import loader
 
 app = Flask(__name__)
 Compress(app)
-
-from config import *
 
 
 def _atomically_dump(f, target_path):
@@ -96,11 +95,11 @@ def _extract_level(zip_url):
             try:
                 episode_id = len(level_info['maps'])
 
-                surfaces, model_surfaces, materials = loader.load_level_from_gob(
+                surfaces, model_surfaces, sky_surfaces, materials, spawn_points = loader.load_level_from_gob(
                     levelname, gob_path)
 
                 # divide vertex UVs by texture sizes
-                for src in [surfaces, model_surfaces]:
+                for src in [surfaces, model_surfaces, sky_surfaces]:
                     for surf in src:
                         mat = materials[surf['material']]
                         if mat and 'dims' in mat:
@@ -132,8 +131,8 @@ def _extract_level(zip_url):
                 # assemble map data
                 material_colors = [_encode_color(
                     mat['color']) if mat else '#000000' for mat in materials]
-                map_data = {'surfaces': surfaces, 'model_surfaces': model_surfaces,
-                            'material_colors': material_colors}
+                map_data = {'surfaces': surfaces, 'model_surfaces': model_surfaces, 'sky_surfaces': sky_surfaces,
+                            'material_colors': material_colors, 'spawn_points': spawn_points}
                 _write_cache_atomically(zip_url, episode_id, 'map.json',
                                         'wt', json.dumps(map_data))
 

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,1 @@
-FLASK_DEBUG=1 FLASK_APP=server.py python -m flask run
+FLASK_DEBUG=1 FLASK_APP=server.py python -m flask run --port 8080

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>{{ title }} preview powered by The Massassi Temple</title>
+    <title>{{title}} preview powered by The Massassi Temple</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <style>
@@ -34,14 +34,14 @@
             z-index: 2;
             color: #cccccc;
             visibility: hidden;
-            opacity: 1;
+            opacity: 0;
             transition: 1s opacity;
             cursor: default;
         }
 
         #mapinfo {
             position: absolute;
-            top: 0px;
+            bottom: 0px;
             right: 0px;
             width: 25%;
             padding: 10px;
@@ -65,6 +65,24 @@
             cursor: default;
             margin: 0;
         }
+
+        #spawninfo {
+            position: absolute;
+            bottom: 0px;
+            left: 0px;
+            width: 25%;
+            padding: 10px;
+            box-sizing: border-box;
+            text-align: left;
+            z-index: 3;
+            color: #cccccc;
+            user-select: none;
+            visibility: hidden;
+        }
+
+        #spawninfo span {
+            cursor: pointer;
+        }
     </style>
     <script type="importmap">
     {
@@ -74,6 +92,8 @@
       }
     }
   </script>
+    <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
 </head>
 
 <body>
@@ -82,13 +102,25 @@
         <b>{{title}}</b><br>
         Rotate: left drag. Move: right drag. Zoom: wheel (hold Alt to zoom fast). Re-anchor: double-click.
     </div>
+    <div id="mouseinfofps" class="info">
+        <b>{{title}}</b><br>
+        Look around: left drag. Move: wheel.
+    </div>
     <div id="touchinfo" class="info">
         <b>{{title}}</b><br>
         Rotate: drag. Move: two-finger drag. Zoom: pinch.
     </div>
+    <div id="touchinfofps" class="info">
+        <b>{{title}}</b><br>
+        Look around: drag.
+    </div>
     <div id="mapinfo">
-        <p>Maps:</p>
+        <p><b>Maps:</b></p>
         <ul id="mapinfolist"></ul>
+    </div>
+    <div id="spawninfo">
+        <span id="spawn" class="material-symbols-outlined" title="Jump into map">emoji_people</span>
+        <span id="showwholemap" class="material-symbols-outlined" title="Explore from high above">globe</span>
     </div>
 
     <script src="{{ url_for('static', filename='js/progressbar.min.js') }}"></script>
@@ -122,21 +154,51 @@
             }
         }
 
-        function showInfo() {
-            // show platform-specific info about controls
-            // and fade the info out after 5 seconds
-            var info = document.getElementById(isTouchDevice ? 'touchinfo' : 'mouseinfo');
-            info.style.visibility = "visible";
-            info.addEventListener('click', function () {
+        var camera, controls, fpsControls, scene, renderer, mesh, skyMesh, materialArray;
+        var spawnPoints, nextSpawnPoint = 0;
+        var fpsControlsScale = 0.0001;
+        var infos = ['touchinfo', 'touchinfofps', 'mouseinfo', 'mouseinfofps'];
+        var lastInfoFadeTimeout;
+
+        function showControlsInfo() {
+            // show platform-specific info about controls and fade out after 5 seconds
+            var selectedInfo = isTouchDevice ? 'touchinfo' : 'mouseinfo';
+            if (!controls.enabled) selectedInfo += 'fps';
+            for (var i = 0; i < infos.length; ++i) {
+                if (infos[i] == selectedInfo) continue;
+                var info = document.getElementById(infos[i]);
+                info.style.visibility = 'hidden';
                 info.style.opacity = '0';
-            }, false);
-            window.setTimeout(function () {
+            }
+            if (lastInfoFadeTimeout) {
+                window.clearTimeout(lastInfoFadeTimeout);
+            }
+
+            var info = document.getElementById(selectedInfo);
+            info.style.opacity = '100';
+            info.style.visibility = 'visible';
+            lastInfoFadeTimeout = window.setTimeout(function () {
                 info.style.opacity = '0';
             }, 5000);
+        }
+
+        function showInfo() {
+            showControlsInfo();
 
             if (maps.length > 1) {
-                var mapinfo = document.getElementById('mapinfo');
-                mapinfo.style.visibility = "visible";
+                document.getElementById('mapinfo').style.visibility = 'visible';
+            }
+
+            if (spawnPoints && spawnPoints.length > 0) {
+                document.getElementById('spawn').onclick = function () {
+                    spawn();
+                    showControlsInfo();
+                };
+                document.getElementById('showwholemap').onclick = function () {
+                    showWholeMap();
+                    showControlsInfo();
+                };
+                document.getElementById('spawninfo').style.visibility = 'visible';
             }
         }
 
@@ -162,7 +224,39 @@
             }
         }
 
-        var camera, controls, scene, renderer, geometry, mesh, materialArray;
+        function showWholeMap() {
+            fpsControls.enabled = false;
+            var bb = mesh.geometry.boundingBox;
+            var center = new THREE.Vector3();
+            bb.getCenter(center);
+            camera.position.copy(bb.max);
+            controls.target.copy(center);
+            controls.enabled = true;
+            controls.update();
+            scene.remove(skyMesh);
+            clearTarget();
+            animate();
+        }
+
+        function spawn() {
+            controls.enabled = false;
+            var spawnPoint = spawnPoints[nextSpawnPoint];
+            nextSpawnPoint = (nextSpawnPoint + 1) % spawnPoints.length;
+            var pos = spawnPoint['pos'];
+            var rot = spawnPoint['rot'];
+            var angle = -rot[1] * Math.PI / 180.0;
+            var dir = [Math.sin(angle) * fpsControlsScale, Math.cos(angle) * fpsControlsScale, 0];
+            var offsetZ = 1 / 16;
+            camera.position.copy(new THREE.Vector3(pos[0], pos[1], pos[2] + offsetZ));
+            fpsControls.target.copy(new THREE.Vector3(pos[0] + dir[0], pos[1] + dir[1], pos[2] + offsetZ + dir[2]));
+            fpsControls.enabled = true;
+            fpsControls.update();
+            if (!scene.getObjectByName('sky')) {
+                scene.add(skyMesh);
+            }
+            clearTarget();
+            animate();
+        }
 
         var progressDone = false;
         progress.setText("Loading ...");
@@ -186,13 +280,7 @@
                 return;
             }
 
-            progress.animate(1, function () {
-                progress.setText("Done!");
-                window.setTimeout(function () {
-                    progressDone = true;
-                    animate(); // rerender
-                }, 1000);
-            });
+            spawnPoints = mapdata['spawn_points'];
 
             materialArray = [];
             var materialColors = mapdata['material_colors'];
@@ -226,36 +314,50 @@
             addSurfaces(mapdata['surfaces']);
             addSurfaces(mapdata['model_surfaces']);
 
-            geometry = new THREE.BufferGeometry();
-            geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
-            geometry.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(uv), 2));
-            var allIndices = [];
-            materialIndices.forEach((indices, material) => {
-                geometry.addGroup(allIndices.length, indices.length, material);
-                allIndices.push(...indices);
-            });
-            geometry.setIndex(allIndices);
-
-            geometry.computeBoundingBox();
-
-            // position camera and configure controls            
-            var bb = geometry.boundingBox;
-            var center = new THREE.Vector3();
-            bb.getCenter(center);
-            camera.position.copy(bb.max);
-            controls.target.copy(center);
-            controls.update();
+            function createGeometry() {
+                var geometry = new THREE.BufferGeometry();
+                geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
+                geometry.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(uv), 2));
+                var allIndices = [];
+                materialIndices.forEach((indices, material) => {
+                    geometry.addGroup(allIndices.length, indices.length, material);
+                    allIndices.push(...indices);
+                });
+                geometry.setIndex(allIndices);
+                geometry.computeBoundingBox();
+                return geometry;
+            }
 
             // create a mesh using the geometry
-            mesh = new THREE.Mesh(geometry, materialArray);
+            mesh = new THREE.Mesh(createGeometry(), materialArray);
             scene.add(mesh);
+
+            // reset and create a separate mesh for the sky
+            // don't add it yet - we want it only when in first-person mode
+            pos = []
+            uv = [];
+            materialIndices = new Map();
+            addSurfaces(mapdata['sky_surfaces']);
+            skyMesh = new THREE.Mesh(createGeometry(), materialArray);
+            skyMesh.name = 'sky';
+
+            showWholeMap();
 
             // render the first frame with the mesh
             animate();
 
             // enable user interaction now
             controls.addEventListener('change', animate);
+            fpsControls.addEventListener('change', animate);
             document.addEventListener('dblclick', onDblClick, false);
+
+            progress.animate(1, function () {
+                progress.setText("Done!");
+                window.setTimeout(function () {
+                    progressDone = true;
+                    animate(); // rerender
+                }, 400);
+            });
         }
 
         function debounce(callback, timeout) {
@@ -328,6 +430,12 @@
             controls.rotateSpeed = 0.25;
             controls.zoomSpeed = 0.5;
 
+            fpsControls = new OrbitControls(camera, renderer.domElement);
+            fpsControls.enableKeys = false;
+            fpsControls.rotateSpeed = 0.75;
+            fpsControls.enableZoom = false;
+            fpsControls.enabled = false;
+
             if (!isTouchDevice) {
                 // alt held speeds up zooming
                 window.addEventListener("keyup", function (ev) {
@@ -335,6 +443,16 @@
                 });
                 window.addEventListener("keydown", function (ev) {
                     if (ev.key == 'Alt') controls.zoomSpeed = 2;
+                });
+                // allow movement by scrolling the mouse up/down for fpsControls
+                window.addEventListener("wheel", function (ev) {
+                    if (!fpsControls.enabled) return;
+                    var zoomSpeed = 0.0025;
+                    const forward = new THREE.Vector3();
+                    camera.getWorldDirection(forward);
+                    camera.position.add(forward.clone().multiplyScalar(-ev.deltaY * zoomSpeed));
+                    fpsControls.target.copy(camera.position.clone().add(forward.clone().multiplyScalar(fpsControlsScale)));
+                    fpsControls.update();
                 });
             }
 
@@ -403,8 +521,13 @@
         }
 
         function updateTarget(pos) {
+            if (!controls.enabled) return;
             nextTarget = pos;
             doUpdateTarget();
+        }
+
+        function clearTarget() {
+            nextTarget = null;
         }
 
         function onDblClick(event) {
@@ -418,9 +541,6 @@
             if (intersects.length > 0) {
                 var first = intersects[0];
                 updateTarget(first.point);
-                // FOR DEVELOPMENT: determine material at intersected point
-                // var mat = geometry.faces[first.faceIndex].materialIndex;
-                // alert(materialArray[mat].name);
             }
         }
 


### PR DESCRIPTION
In the bottom left we add two buttons: one to spawn in the map, the other one to return to a bird's eye view. When spawned in the map, change controls to FPS style (drag to look around, scroll to move forward/backward to have some consistency with the orbit controls). On touch devices we could move if the user holds down a finger (started delayed after 1 sec) ..? Not implemented, so can only look around.

Note that we need new information about the map (spawn points), so I'm bumping the VERSION in the config.py. Needs to be done on installations to invalidate anything cached.